### PR TITLE
Fix pack parsing

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1073,9 +1073,9 @@ static bool parseLoader(FILE* file) {
 		if (fscanf(file, OPT_LOADER_NAME "%d=%s", &index, buf)
 				!= 2)
 			return false;
-		index--;
 		strcpy(gOpts.loader[index].name, buf);
 		printf("name%d: %s\n", index, gOpts.loader[index].name);
+		index++;
 	}
 	for (i=0; i<gOpts.loaderNum; i++) {
 		if (SCANF_EAT(file) != 0) {


### PR DESCRIPTION
The index needѕ to be incremented after a valid path was found. Otherwise
gOpts.loader[index].name will be out of of bound after the second
iteration.

Signed-off-by: Klaus Goger <klaus.goger@theobroma-systems.com>