### PR TITLE
Fixed Build Failure - gcc 8.2.0

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2838,7 +2838,7 @@ void split_item(STRING_VECTOR &vecItems, char *pszItems)
 	}
 	if (strlen(pStart) > 0) {
 		memset(szItem, 0, 100);
-		strncpy(szItem, pStart, strlen(pStart));
+		strncpy(szItem, pStart, 100-1);
 		strItem = szItem;
 		vecItems.push_back(strItem);
 	}


### PR DESCRIPTION
This 1 line change try to fix the following compile failure (one of the current open issue) error:

main.cpp:2841:10: error: ‘char* strncpy(char*, const char*, size_t)’
output truncated before terminating nul copying as many bytes from
a string as its length [-Werror=stringop-truncation]

Since the allocation is only 100*char, the reasonable fix would be
limit the strncpy to only (100-1)*char.