### PR TITLE
parse_parameter: Continue parsing after 'mtdparts'.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -483,7 +483,6 @@ bool parse_parameter(char *pParameter, PARAM_ITEM_VECTOR &vecItem, CONFIG_ITEM_V
 				vecItem.push_back(item);
 			}
 		}
-		break;
 	}
 	return bFind;
 


### PR DESCRIPTION
The parse_paramter loop iterates over a parameter.txt file's contents
and parses that line-by-line. However, the current implementation
silently stops after parsing 'mtdparts'. This is problematic if
a 'uuid' token is found in one of the following lines.

This patch addresses the problem, by simply continue to iterate
over the next lines after 'mtdparts'.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>