### PR TITLE
Fix compilation issue in split_item().

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -2827,7 +2827,7 @@ void split_item(STRING_VECTOR &vecItems, char *pszItems)
 	pStart = pszItems;
 	pos = strchr(pStart, ',');
 	while(pos != NULL) {
-		memset(szItem, 0, 100);
+		memset(szItem, 0, sizeof(szItem));
 		strncpy(szItem, pStart, pos - pStart);
 		strItem = szItem;
 		vecItems.push_back(strItem);
@@ -2837,8 +2837,8 @@ void split_item(STRING_VECTOR &vecItems, char *pszItems)
 		pos = strchr(pStart, ',');
 	}
 	if (strlen(pStart) > 0) {
-		memset(szItem, 0, 100);
-		strncpy(szItem, pStart, strlen(pStart));
+		memset(szItem, 0, sizeof(szItem));
+		strncpy(szItem, pStart, sizeof(szItem)-1);
 		strItem = szItem;
 		vecItems.push_back(strItem);
 	}


### PR DESCRIPTION
Recent compilers complain with the following message:

  main.cpp: In function ‘void split_item(STRING_VECTOR&, char*)’:
  main.cpp:2840:10: error: ‘char* strncpy(char*, const char*, size_t)’ output truncated before terminating nul copying as many bytes from a string as its length

This patch addresses this issue.

Signed-off-by: Christoph Muellner <christoph.muellner@theobroma-systems.com>