### PR TITLE
Use signed char for variable

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1882,7 +1882,7 @@ bool upgrade_loader(STRUCT_RKDEVICE_DESC &dev, char *szLoader)
 	CRKComm *pComm = NULL;
 	bool bRet, bSuccess = false;
 	int iRet;
-	char index;
+	signed char index;
 	USHORT usFlashDataSec, usFlashBootSec;
 	DWORD dwLoaderSize, dwLoaderDataSize, dwDelay, dwSectorNum;
 	char loaderCodeName[] = "FlashBoot";


### PR DESCRIPTION
Architectures other than x86 don't by default treat char as signed so
be explicit so the build doesn't fail when building on other arches
such as Arm. Fixes #41 

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>