### PR TITLE
parserLoader: Fix loader name index in LOADER_OPTION.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1194,8 +1194,9 @@ static bool parseLoader(FILE* file) {
 		if (fscanf(file, OPT_LOADER_NAME "%d=%s", &index, buf)
 				!= 2)
 			return false;
+		index--;
 		strcpy(gOpts.loader[index].name, buf);
-		printf("name%d: %s\n", index, gOpts.loader[index].name);
+		printf("name%d: %s\n", index+1, gOpts.loader[index].name);
 		index++;
 	}
 	for (i=0; i<gOpts.loaderNum; i++) {


### PR DESCRIPTION
As show in the config.ini, the loader name should start with 1, not 0.

Before `rkdeveloptool pack' worked with:
  [LOADER_OPTION]
  NUM=2
  LOADER0=FOO
  LOADER1=BAR

Now it works with:
  [LOADER_OPTION]
  NUM=2
  LOADER1=FOO
  LOADER2=BAR