### PR TITLE
use a safe way to copy the chip string

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1490,7 +1490,7 @@ static bool saveEntry(FILE* outFile, char* path, rk_entry_type type,
 static inline uint32_t convertChipType(const char* chip) {
 	char buffer[5];
 	memset(buffer, 0, sizeof(buffer));
-	snprintf(buffer, sizeof(buffer), "%s", chip);
+	memccpy(buffer, chip, '\0', sizeof(buffer));
 	return buffer[0] << 24 | buffer[1] << 16 | buffer[2] << 8 | buffer[3];
 }
 


### PR DESCRIPTION
based on https://developers.redhat.com/blog/2019/08/12/efficient-string-copying-and-concatenation-in-c

Fixes: https://github.com/rockchip-linux/rkdeveloptool/issues/55