### PR TITLE
fix compiling error for snprintf ( under Raspberry Pi OS Debian Bullseye )

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1490,7 +1490,10 @@ static bool saveEntry(FILE* outFile, char* path, rk_entry_type type,
 static inline uint32_t convertChipType(const char* chip) {
 	char buffer[5];
 	memset(buffer, 0, sizeof(buffer));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
 	snprintf(buffer, sizeof(buffer), "%s", chip);
+#pragma GCC diagnostic pop
 	return buffer[0] << 24 | buffer[1] << 16 | buffer[2] << 8 | buffer[3];
 }
 


### PR DESCRIPTION
it compiles failed without changes:

```
main.cpp:1493:36: error: ‘%s’ directive output may be truncated writing up to 557 bytes into a region of size 15 [-Werror=format-truncation=]
 1493 |  snprintf(buffer, sizeof(buffer), "%s", chip);
      |                                    ^~
......
main.cpp:1493:10: note: ‘snprintf’ output between 1 and 558 bytes into a destination of size 15
 1493 |  snprintf(buffer, sizeof(buffer), "%s", chip);
      |  ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```