### PR TITLE
Making creation of loader file reproducible

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1511,7 +1511,7 @@ static bool saveEntry(FILE* outFile, char* path, rk_entry_type type,
 static inline uint32_t convertChipType(const char* chip) {
 	char buffer[5];
 	memset(buffer, 0, sizeof(buffer));
-	memcpy(buffer, chip, sizeof(buffer));
+	memccpy(buffer, chip, '\0', sizeof(buffer));
 	return buffer[0] << 24 | buffer[1] << 16 | buffer[2] << 8 | buffer[3];
 }
 


### PR DESCRIPTION
by setting fixed rkTime, more info: https://github.com/martinSusz/rkdeveloptool/wiki/Generating--quasi-reproducible-BootROM-firmware-for-Rock-Chips-SoC