### PR TITLE
Fix string formatting problem

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1490,7 +1490,7 @@ static bool saveEntry(FILE* outFile, char* path, rk_entry_type type,
 static inline uint32_t convertChipType(const char* chip) {
 	char buffer[5];
 	memset(buffer, 0, sizeof(buffer));
-	snprintf(buffer, sizeof(buffer), "%s", chip);
+	snprintf(buffer, sizeof(buffer), "%.*s", static_cast<int>(sizeof(buffer) - 1), chip);
 	return buffer[0] << 24 | buffer[1] << 16 | buffer[2] << 8 | buffer[3];
 }
 


### PR DESCRIPTION
 solve string formatting problem (#80) with error:

> make[1]: Entrando no diretório '/home/${USER}/rkdeveloptool'
> g++ -DHAVE_CONFIG_H -I. -I./cfg  -Wall -Werror -Wextra -Wreturn-type -fno-strict-aliasing -D_FILE_OFFSET_BITS=64 -D_LARGE_FILE -I/usr/include/libusb-1.0   -g -O2 -MT main.o -MD -MP -MF .deps/main.Tpo -c -o main.o main.cpp
> main.cpp: In function ‘bool _Z9mergeBootv.part.0()’:
> main.cpp:1493:43: error: ‘%s’ directive output may be truncated writing up to 557 bytes into a region of size 5 [-Werror=format-truncation=]
>  1493 |         snprintf(buffer, sizeof(buffer), "%s", chip);
>       |                                           ^~
> ......
>  1534 |                 chipType = convertChipType(chip + 2);
>       |                            ~~~~~~~~~~~~~~~~~~~~~~~~~
> In file included from /usr/include/stdio.h:894,
>                  from DefineHeader.h:3,
>                  from main.cpp:11:
> /usr/include/x86_64-linux-gnu/bits/stdio2.h:71:35: note: ‘__builtin_snprintf’ output between 1 and 558 bytes into a destination of size 5
>    71 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
>       |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>    72 |                                    __glibc_objsize (__s), __fmt,
>       |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
>    73 |                                    __va_arg_pack ());
>       |                                    ~~~~~~~~~~~~~~~~~
> cc1plus: all warnings being treated as errors
> make[1]: *** [Makefile:491: main.o] Erro 1
> make[1]: Saindo do diretório '/home/yan/rkdeveloptool'
> make: *** [Makefile:511: all-recursive] Erro 1

