### PR TITLE
Update main.cpp

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1490,7 +1490,7 @@ static bool saveEntry(FILE* outFile, char* path, rk_entry_type type,
 static inline uint32_t convertChipType(const char* chip) {
 	char buffer[5];
 	memset(buffer, 0, sizeof(buffer));
-	snprintf(buffer, sizeof(buffer), "%s", chip);
+	snprintf(buffer, sizeof(buffer), "%.4s", chip);
 	return buffer[0] << 24 | buffer[1] << 16 | buffer[2] << 8 | buffer[3];
 }
 


### PR DESCRIPTION
Compiling error:
=================================================
user@ubuntu-22.04: ~/rkdeveloptool$ make
make[1]: Entering directory '/home/roy/rkdeveloptool'
g++ -DHAVE_CONFIG_H -I. -I./cfg  -Wall -Werror -Wextra -Wreturn-type -fno-strict-aliasing -D_FILE_OFFSET_BITS=64 -D_LARGE_FILE -I/usr/include/libusb-1.0   -g -O2 -MT main.o -MD -MP -MF .deps/main.Tpo -c -o main.o main.cpp
main.cpp: In function ‘bool _Z9mergeBootv.part.0()’:
main.cpp:1493:43: error: ‘%s’ directive output may be truncated writing up to 557 bytes into a region of size 5 [-Werror=format-truncation=]
 1493 |         snprintf(buffer, sizeof(buffer), "%s", chip);
      |                                           ^~
......
 1534 |                 chipType = convertChipType(chip + 2);
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:894,
                 from DefineHeader.h:3,
                 from main.cpp:11:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:71:35: note: ‘__builtin_snprintf’ output between 1 and 558 bytes into a destination of size 5
   71 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   72 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   73 |                                    __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[1]: *** [Makefile:491: main.o] Error 1
make[1]: Leaving directory '/home/roy/rkdeveloptool'
make: *** [Makefile:511: all-recursive] Error 1



Possible reason:
=================================================
The error is due to a format-truncation warning being treated as an error during compilation. This occurs when you're trying to write more characters to a buffer than it can hold, which can lead to buffer overflow issues.

To fix this issue, you need to ensure that the buffer size used in the snprintf call is large enough to accommodate the string being formatted. In this case, it seems that the buffer size is set to 5 bytes, but the string being formatted (chip) might be longer than that.


Fix:
=================================================
Mentioning the length in line 1493 (main.cpp)

snprintf(buffer, sizeof(buffer), "%.4s", chip);