### PR TITLE
Add the capability to change the storage (eMMC, SD, SPINOR...).

### DIFF
--- a/RKComm.h
+++ b/RKComm.h
@@ -49,6 +49,8 @@ typedef enum {
 		WRITE_NEW_EFUSE = 0x23,
 		READ_NEW_EFUSE = 0x24,
 		ERASE_LBA=0x25,
+		CHANGE_STORAGE = 0x2A,
+		READ_STORAGE = 0x2B,
 		READ_CAPABILITY=0xAA,
 		DEVICE_RESET = 0xFF
 } USB_OPERATION_CODE;
@@ -142,6 +144,8 @@ class CRKUsbComm:public CRKComm
 {
 public:
 	virtual	int RKU_EraseBlock(BYTE ucFlashCS, DWORD dwPos, DWORD dwCount, BYTE ucEraseType);
+	virtual int RKU_ChangeStorage(BYTE storage);
+	virtual int RKU_ReadStorage(BYTE *storage);
 	virtual int RKU_ReadChipInfo(BYTE *lpBuffer);
 	virtual int RKU_ReadFlashID(BYTE *lpBuffer);
 	virtual int RKU_ReadCapability(BYTE *lpBuffer);


### PR DESCRIPTION
Implemented by reverse engineering of windows RKDevTool USB transactions. The naming of operations (eg. READ_STORAGE, CHANGE_STORAGE) are pure speculation, but the result is effective.
Also, the numbering of storage device (eg. 1=eMMC, 2=SD, 9=SPINOR) may be dependent of the SOC.

Developed and tested on rk3588 (Radxa Rock 5 ITX)

Example of usage:
```
  rkdeveloptool db rk3588_spl_loader_v1.15.113.bin
  # select the SPINOR
  rkdeveloptool cs 9
  # clear the whole SPINOR device
  rkdeveloptool ef

  # write an image starting at block 0
  rkdeveloptool wl 0 /tmp/spinor_image.bin
```